### PR TITLE
Remove the connector binary from Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea/
 
 # Binary built with `make build`
-/conduit-connector-bigquery
+conduit-connector-bigquery
 cover.html


### PR DESCRIPTION
### Description

This PR:

- Remove the connector binary (`conduit-connector-bigquery`) from Git

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-s3/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
